### PR TITLE
Replace Traefik with Nginx for ingress controller

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
   - service-bus.yaml
   - serviceaccount.yaml
 
+generatorOptions:
+  disableNameSuffixHash: true
+
 configMapGenerator:
   - name: service-bus
     files:

--- a/deploy/nginx-ingress/values.yaml
+++ b/deploy/nginx-ingress/values.yaml
@@ -1,3 +1,4 @@
+# See https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx#values for configuration reference
 controller:
   proxySetHeaders:
     X-Original-Host: "$host"

--- a/deploy/nginx-ingress/values.yaml
+++ b/deploy/nginx-ingress/values.yaml
@@ -1,0 +1,3 @@
+controller:
+  proxySetHeaders:
+    X-Original-Host: "$host"

--- a/helm-charts/webapp/templates/ingress.yaml
+++ b/helm-charts/webapp/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
   tls:
     {{- range $hostsList }}
     - hosts:

--- a/lima/k3s-local-dev.yaml
+++ b/lima/k3s-local-dev.yaml
@@ -73,7 +73,7 @@ provision:
 
       # Install k3s
       if [ ! -d /var/lib/rancher/k3s ]; then
-        curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644" sh -
+        curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik --write-kubeconfig-mode 644" sh -
       fi
 
       # Install Docker if not already present

--- a/scripts/lima-k3s.sh
+++ b/scripts/lima-k3s.sh
@@ -85,7 +85,7 @@ docker context use lima-ipaffs
 export KUBECONFIG="${HOME}/.lima/ipaffs/copied-from-guest/kubeconfig.yaml"
 
 # Install nginx ingress controller
-helm upgrade --install nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx --namespace kube-system
+helm upgrade --install nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx --namespace kube-system --values "${REPO_DIR}/deploy/nginx-ingress/values.yaml"
 
 # Build SQL Server container
 echo -e "${BLUE}:: Building database container image${NC}"

--- a/scripts/lima-k3s.sh
+++ b/scripts/lima-k3s.sh
@@ -84,6 +84,9 @@ docker context use lima-ipaffs
 # Configure kubectl to connect to IPAFFS VM
 export KUBECONFIG="${HOME}/.lima/ipaffs/copied-from-guest/kubeconfig.yaml"
 
+# Install nginx ingress controller
+helm upgrade --install nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx --namespace kube-system
+
 # Build SQL Server container
 echo -e "${BLUE}:: Building database container image${NC}"
 docker build --platform=linux/amd64 -t import-notification-database "${IMPORTS_DIR}/docker-local/database"


### PR DESCRIPTION
Allows us to set the `X-Original-Host` header for proxied requests to that `imports-proxy` can parse B2C vs. B2C URLs.