### PR TITLE
Make all pipelines cancellable

### DIFF
--- a/pipelines/backoffice-chart.yaml
+++ b/pipelines/backoffice-chart.yaml
@@ -87,7 +87,7 @@ stages:
     jobs:
       - job: PackageFeatureBranch
         displayName: Package from feature branch (DEV)
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
         steps:
           - task: AzureCLI@2
             name: pushChartToRegistry
@@ -115,7 +115,7 @@ stages:
 
       - job: PackageMainBranch
         displayName: Bump chart version and package from main branch (DEV)
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         steps:
           - checkout: self
             persistCredentials: true
@@ -173,6 +173,7 @@ stages:
       displayName: Update ipaffs-manifest backoffice chart version
       dependsOn: Package_DEV
       condition: and(
+        not(failed()), not(canceled()),
         eq(dependencies.Package_DEV.result, 'Succeeded'),
         startsWith(variables['Build.SourceBranch'], 'refs/heads/')
         )
@@ -241,7 +242,7 @@ stages:
             - task: Bash@3
               name: ResolveChartVersion
               displayName: Resolve chart version
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 FEATURE_CHART_VERSION: "$(featureChartVersion)"
                 MAIN_CHART_VERSION: "$(mainChartVersion)"
@@ -265,7 +266,7 @@ stages:
 
             - task: Bash@3
               displayName: Update chart version in manifest helmfile
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 CHART_NAME: $(helmChartName)
                 CHART_VERSION: "$(chartVersion)"
@@ -277,7 +278,7 @@ stages:
 
             - task: Bash@3
               displayName: Commit and push manifest changes
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 CHART_NAME: $(helmChartName)
                 CHART_VERSION: "$(chartVersion)"

--- a/pipelines/bootstrap-chart.yaml
+++ b/pipelines/bootstrap-chart.yaml
@@ -91,7 +91,7 @@ stages:
     jobs:
       - job: PackageFeatureBranch
         displayName: Package from feature branch (DEV)
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
         steps:
           - task: AzureCLI@2
             name: pushChartToRegistry
@@ -119,7 +119,7 @@ stages:
 
       - job: PackageMainBranch
         displayName: Bump chart version and package from main branch (DEV)
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         steps:
           - checkout: self
             persistCredentials: true
@@ -177,6 +177,7 @@ stages:
       displayName: Update ipaffs-manifest bootstrap values
       dependsOn: Package_DEV
       condition: and(
+        not(failed()), not(canceled()),
         eq(dependencies.Package_DEV.result, 'Succeeded'),
         startsWith(variables['Build.SourceBranch'], 'refs/heads/')
         )
@@ -245,7 +246,7 @@ stages:
             - task: Bash@3
               name: ResolveBootstrapChartVersion
               displayName: Resolve bootstrap chart version
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 FEATURE_CHART_VERSION: "$(featureChartVersion)"
                 MAIN_CHART_VERSION: "$(mainChartVersion)"
@@ -269,7 +270,7 @@ stages:
 
             - task: Bash@3
               displayName: Update bootstrap values files
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 CHART_VERSION: "$(bootstrapChartVersion)"
                 MANIFEST_ROOT: "$(Pipeline.Workspace)/s/ipaffs-manifest"
@@ -281,7 +282,7 @@ stages:
 
             - task: Bash@3
               displayName: Commit and push manifest changes
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 BUILD_NUMBER: $(Build.BuildNumber)
                 MANIFEST_BRANCH: "$(targetManifestBranch)"

--- a/pipelines/job-chart.yaml
+++ b/pipelines/job-chart.yaml
@@ -87,7 +87,7 @@ stages:
     jobs:
       - job: PackageFeatureBranch
         displayName: Package from feature branch (DEV)
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
         steps:
           - task: AzureCLI@2
             name: pushChartToRegistry
@@ -115,7 +115,7 @@ stages:
 
       - job: PackageMainBranch
         displayName: Bump chart version and package from main branch (DEV)
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         steps:
           - checkout: self
             persistCredentials: true
@@ -173,6 +173,7 @@ stages:
       displayName: Update ipaffs-manifest job chart version
       dependsOn: Package_DEV
       condition: and(
+        not(failed()), not(canceled()),
         eq(dependencies.Package_DEV.result, 'Succeeded'),
         startsWith(variables['Build.SourceBranch'], 'refs/heads/')
         )
@@ -241,7 +242,7 @@ stages:
             - task: Bash@3
               name: ResolveChartVersion
               displayName: Resolve chart version
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 FEATURE_CHART_VERSION: "$(featureChartVersion)"
                 MAIN_CHART_VERSION: "$(mainChartVersion)"
@@ -265,7 +266,7 @@ stages:
 
             - task: Bash@3
               displayName: Update chart version in manifest helmfile
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 CHART_NAME: $(helmChartName)
                 CHART_VERSION: "$(chartVersion)"
@@ -277,7 +278,7 @@ stages:
 
             - task: Bash@3
               displayName: Commit and push manifest changes
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 CHART_NAME: $(helmChartName)
                 CHART_VERSION: "$(chartVersion)"

--- a/pipelines/jobs/build-java-project.yaml
+++ b/pipelines/jobs/build-java-project.yaml
@@ -6,7 +6,7 @@ parameters:
 jobs:
   - job: BuildJavaProject
     displayName: Build Java Project
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+    condition: and(not(failed()), not(canceled()), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
     variables:
       MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
       MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'

--- a/pipelines/jobs/deploy-identities.yaml
+++ b/pipelines/jobs/deploy-identities.yaml
@@ -16,7 +16,7 @@ parameters:
 jobs:
   - job: MigrationsIdentity
     displayName: Set up Migrations Identity
-    condition: ${{ eq(parameters.migrations, true) }}
+    condition: and(not(failed()), not(canceled()), ${{ eq(parameters.migrations, true) }})
     variables:
       - group: "${{ parameters.environmentName }}"
       - template: "/pipelines/vars/common.yaml"

--- a/pipelines/jobs/package-java-project.yaml
+++ b/pipelines/jobs/package-java-project.yaml
@@ -26,7 +26,7 @@ jobs:
 
   - job: PackageMigrationsImage
     displayName: Package Migrations Image
-    condition: ${{ eq(parameters.migrations, true) }}
+    condition: and(not(failed()), not(canceled()), ${{ eq(parameters.migrations, true) }})
     steps:
       - template: /pipelines/steps/build-container-image.yaml@ipaffs-infra
         parameters:

--- a/pipelines/legacy.yml
+++ b/pipelines/legacy.yml
@@ -69,7 +69,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Deploy - Classic
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(classicServiceConnection)
                     scriptType: bash

--- a/pipelines/stages/deploy-bicep-acr.yaml
+++ b/pipelines/stages/deploy-bicep-acr.yaml
@@ -81,7 +81,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Deploy - ACR
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash
@@ -97,7 +97,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Wait for Deployment - ACR
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash

--- a/pipelines/stages/deploy-bicep-classic.yaml
+++ b/pipelines/stages/deploy-bicep-classic.yaml
@@ -97,7 +97,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Deploy - Classic
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(classicServiceConnection)
                     scriptType: bash
@@ -114,7 +114,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Wait for Deployment - Classic
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(classicServiceConnection)
                     scriptType: bash
@@ -144,7 +144,7 @@ stages:
           - task: AzureCLI@2
             name: ClassicOutputs
             displayName: Classic outputs
-            condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+            condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
             env:
               ADO_ORG_URL: $(System.CollectionUri)
               ADO_PROJECT: $(System.TeamProject)

--- a/pipelines/stages/deploy-bicep-infra.yaml
+++ b/pipelines/stages/deploy-bicep-infra.yaml
@@ -147,7 +147,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Deploy - Infrastructure
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash
@@ -164,7 +164,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Wait for Deployment - Infrastructure
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash
@@ -194,7 +194,7 @@ stages:
           - task: AzureCLI@2
             name: InfrastructureOutputs
             displayName: Infrastructure outputs
-            condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+            condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
             env:
               ADO_ORG_URL: $(System.CollectionUri)
               ADO_PROJECT: $(System.TeamProject)

--- a/pipelines/stages/deploy-bicep-network.yaml
+++ b/pipelines/stages/deploy-bicep-network.yaml
@@ -37,7 +37,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Deploy - Network
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash
@@ -53,7 +53,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Wait for Deployment - Network
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash
@@ -83,7 +83,7 @@ stages:
           - task: AzureCLI@2
             name: NetworkOutputs
             displayName: Network outputs
-            condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+            condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
             env:
               ADO_ORG_URL: $(System.CollectionUri)
               ADO_PROJECT: $(System.TeamProject)
@@ -129,7 +129,7 @@ stages:
                 - checkout: self
 
                 - task: Bash@3
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   env:
                     ADO_ORG_URL: $(System.CollectionUri)
                     ADO_PROJECT: $(System.TeamProject)

--- a/pipelines/stages/deploy-bicep-privatelink.yaml
+++ b/pipelines/stages/deploy-bicep-privatelink.yaml
@@ -37,7 +37,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Deploy - PrivateLink
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash
@@ -53,7 +53,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Wait for Deployment - PrivateLink
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash

--- a/pipelines/stages/deploy-bicep-resource-group.yaml
+++ b/pipelines/stages/deploy-bicep-resource-group.yaml
@@ -37,7 +37,7 @@ stages:
 
                 - task: AzureCLI@2
                   displayName: Deploy - ResourceGroup
-                  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                  condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                   inputs:
                     azureSubscription: $(serviceConnection)
                     scriptType: bash

--- a/pipelines/stages/import-acr-artifacts.yaml
+++ b/pipelines/stages/import-acr-artifacts.yaml
@@ -10,7 +10,7 @@ stages:
         displayName: Import Container Images
         environment:
           name: "${{ parameters.environmentName }}"
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         strategy:
           runOnce:
             deploy:

--- a/pipelines/stages/infra-permissions.yaml
+++ b/pipelines/stages/infra-permissions.yaml
@@ -18,7 +18,7 @@ stages:
         displayName: Group Memberships
         environment:
           name: "${{ parameters.environmentName }}"
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         strategy:
           runOnce:
             deploy:

--- a/pipelines/stages/package-helm-chart.yaml
+++ b/pipelines/stages/package-helm-chart.yaml
@@ -23,7 +23,7 @@ stages:
 
       - job: PackageFeatureBranch
         displayName: Package from feature branch
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
         dependsOn: ExtractVersionFromChart
         variables:
           helmChartVersion: $[ dependencies.ExtractVersionFromChart.outputs['ComputeVersion.helmChartVersion'] ]
@@ -45,7 +45,7 @@ stages:
 
       - job: PackageMainBranch
         displayName: Bump chart version and package from main branch
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         dependsOn: ExtractVersionFromChart
         variables:
           helmChartVersion: $[ dependencies.ExtractVersionFromChart.outputs['ComputeVersion.helmChartVersion'] ]

--- a/pipelines/stages/private-endpoint-dns-records.yaml
+++ b/pipelines/stages/private-endpoint-dns-records.yaml
@@ -35,7 +35,7 @@ stages:
                           -Subscription '$(subscriptionName)'
 
                       - displayName: "ACR: Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true
@@ -55,7 +55,7 @@ stages:
                           -Subscription '$(subscriptionName)'
 
                       - displayName: "KeyVault: Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true
@@ -75,7 +75,7 @@ stages:
                           -Subscription '$(subscriptionName)'
 
                       - displayName: "Redis: Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true
@@ -95,7 +95,7 @@ stages:
                           -Subscription '$(classicSubscriptionName)'
 
                       - displayName: "Redis (Classic): Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true
@@ -115,7 +115,7 @@ stages:
                           -Subscription '$(subscriptionName)'
 
                       - displayName: "Search: Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true
@@ -135,7 +135,7 @@ stages:
                           -Subscription '$(classicSubscriptionName)'
 
                       - displayName: "Search (Classic): Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true
@@ -155,7 +155,7 @@ stages:
                           -Subscription '$(subscriptionName)'
 
                       - displayName: "Storage: Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true
@@ -175,7 +175,7 @@ stages:
                           -Subscription '$(subscriptionName)'
 
                       - displayName: "SQL: Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true
@@ -195,7 +195,7 @@ stages:
                           -Subscription '$(classicSubscriptionName)'
 
                       - displayName: "SQL (Classic): Set DNS records"
-                        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+                        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
                         scriptPath: 'Set-PrivateDnsRecordSet.ps1@PipelineCommon'
                         scriptArguments: >
                           -UpdateAllDnsZones $true

--- a/pipelines/templates/java-template.yaml
+++ b/pipelines/templates/java-template.yaml
@@ -102,6 +102,7 @@ stages:
     displayName: Build Service
     dependsOn: DetectContainerBuild
     condition: and(
+      not(failed()), not(canceled()),
       eq(dependencies.DetectContainerBuild.result, 'Succeeded'),
       ne(dependencies.DetectContainerBuild.outputs['DetermineBuildMode.SetBuildMode.skipContainerBuild'], 'true')
       )
@@ -116,6 +117,7 @@ stages:
       - DetectContainerBuild
       - BuildService
     condition: and(
+      not(failed()), not(canceled()),
       eq(dependencies.DetectContainerBuild.result, 'Succeeded'),
       ne(dependencies.DetectContainerBuild.outputs['DetermineBuildMode.SetBuildMode.skipContainerBuild'], 'true'),
       eq(dependencies.BuildService.result, 'Succeeded')
@@ -137,6 +139,7 @@ stages:
         - name: skipContainerBuild
           value: $[ stageDependencies.DetectContainerBuild.DetermineBuildMode.outputs['SetBuildMode.skipContainerBuild'] ]
       condition: and(
+        not(failed()), not(canceled()),
         eq(dependencies.DetectContainerBuild.result, 'Succeeded'),
         startsWith(variables['Build.SourceBranch'], 'refs/heads/'),
         or(
@@ -206,7 +209,7 @@ stages:
 
             - task: Bash@3
               displayName: Update service values files
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 SERVICE_NAME: "${{ parameters.serviceName }}"
                 BUILD_NUMBER: $(Build.BuildNumber)
@@ -221,7 +224,7 @@ stages:
 
             - task: Bash@3
               displayName: Commit and push manifest changes
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 SERVICE_NAME: "${{ parameters.serviceName }}"
                 BUILD_NUMBER: $(Build.BuildNumber)

--- a/pipelines/templates/node-template.yaml
+++ b/pipelines/templates/node-template.yaml
@@ -93,6 +93,7 @@ stages:
     displayName: Build Service
     dependsOn: DetectContainerBuild
     condition: and(
+      not(failed()), not(canceled()),
       eq(dependencies.DetectContainerBuild.result, 'Succeeded'),
       ne(dependencies.DetectContainerBuild.outputs['DetermineBuildMode.SetBuildMode.skipContainerBuild'], 'true')
       )
@@ -107,6 +108,7 @@ stages:
       - DetectContainerBuild
       - BuildService
     condition: and(
+      not(failed()), not(canceled()),
       eq(dependencies.DetectContainerBuild.result, 'Succeeded'),
       ne(dependencies.DetectContainerBuild.outputs['DetermineBuildMode.SetBuildMode.skipContainerBuild'], 'true'),
       eq(dependencies.BuildService.result, 'Succeeded')
@@ -127,6 +129,7 @@ stages:
         - name: skipContainerBuild
           value: $[ stageDependencies.DetectContainerBuild.DetermineBuildMode.outputs['SetBuildMode.skipContainerBuild'] ]
       condition: and(
+        not(failed()), not(canceled()),
         eq(dependencies.DetectContainerBuild.result, 'Succeeded'),
         startsWith(variables['Build.SourceBranch'], 'refs/heads/'),
         or(
@@ -196,7 +199,7 @@ stages:
 
             - task: Bash@3
               displayName: Update service values files
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 SERVICE_NAME: "${{ parameters.serviceName }}"
                 BUILD_NUMBER: $(Build.BuildNumber)
@@ -211,7 +214,7 @@ stages:
 
             - task: Bash@3
               displayName: Commit and push manifest changes
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 SERVICE_NAME: "${{ parameters.serviceName }}"
                 BUILD_NUMBER: $(Build.BuildNumber)

--- a/pipelines/webapp-chart.yaml
+++ b/pipelines/webapp-chart.yaml
@@ -97,7 +97,7 @@ stages:
 
       - job: PackageFeatureBranch
         displayName: Package from feature branch (DEV)
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
         dependsOn: TestWebappChart
         steps:
           - task: AzureCLI@2
@@ -126,7 +126,7 @@ stages:
 
       - job: PackageMainBranch
         displayName: Bump chart version and package from main branch (DEV)
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         dependsOn: TestWebappChart
         steps:
           - checkout: self
@@ -185,6 +185,7 @@ stages:
       displayName: Update ipaffs-manifest webapp chart version
       dependsOn: Package_DEV
       condition: and(
+        not(failed()), not(canceled()),
         eq(dependencies.Package_DEV.result, 'Succeeded'),
         startsWith(variables['Build.SourceBranch'], 'refs/heads/')
         )
@@ -253,7 +254,7 @@ stages:
             - task: Bash@3
               name: ResolveChartVersion
               displayName: Resolve chart version
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 FEATURE_CHART_VERSION: "$(featureChartVersion)"
                 MAIN_CHART_VERSION: "$(mainChartVersion)"
@@ -277,7 +278,7 @@ stages:
 
             - task: Bash@3
               displayName: Update chart version in manifest helmfile
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 CHART_NAME: $(helmChartName)
                 CHART_VERSION: "$(chartVersion)"
@@ -289,7 +290,7 @@ stages:
 
             - task: Bash@3
               displayName: Commit and push manifest changes
-              condition: ne(variables['skipManifestUpdate'], 'true')
+              condition: and(not(failed()), not(canceled()), ne(variables['skipManifestUpdate'], 'true'))
               env:
                 CHART_NAME: $(helmChartName)
                 CHART_VERSION: "$(chartVersion)"


### PR DESCRIPTION
Whenever a `condition` is specified for a stage or job, this overrides any implicit condition ADO would have obeyed, such as not running the stage/job if the entire build is cancelled!

See https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml%2Cstages#condition-outcomes-when-a-build-is-canceled

Therefore we must ensure that all custom conditions where we do not want this, include something to the effect of:

`condition: and(not(failed()), not(canceled()), ORIGINAL_CONDITION)`