### PR TITLE
Configure a default TLS certificate for the ingress controller

### DIFF
--- a/helm-charts/app-routing-controller/templates/nginx-ingress-controller.yaml
+++ b/helm-charts/app-routing-controller/templates/nginx-ingress-controller.yaml
@@ -5,6 +5,11 @@ metadata:
 spec:
   ingressClassName: {{ .Values.ingressClassName }}
   controllerNamePrefix: {{ .Values.name }}
+  defaultSSLCertificate:
+    forceSSLRedirect: false
+    secret:
+      name: star-azure-defra-cloud-cert
+      namespace: defra-certs
   {{- with .Values.loadBalancerAnnotations }}
   loadBalancerAnnotations:
     {{- toYaml . | nindent 4 }}

--- a/helm-charts/defra-certs/Chart.yaml
+++ b/helm-charts/defra-certs/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: defra-certs
+version: 0.1.0
+description: Defra TLS Certificates
+# vim: set ts=2 sts=2 sw=2 et:

--- a/helm-charts/defra-certs/templates/external-secret.yaml
+++ b/helm-charts/defra-certs/templates/external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: star-azure-defra-cloud-cert
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: external-secrets-azure-ccoe
+  target:
+    name: star-azure-defra-cloud-cert
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/tls
+      data:
+        tls.crt: "{{ `{{ .pkcs12 | b64dec | pkcs12cert }}` }}"
+        tls.key: "{{ `{{ .pkcs12 | b64dec | pkcs12key }}` }}"
+  data:
+    - secretKey: pkcs12
+      remoteRef:
+        key: secret/star-azure-defra-cloud-cert
+
+# vim: set ts=2 sts=2 sw=2 et:

--- a/helm-charts/ms-identity-redirect-handler/values.yaml
+++ b/helm-charts/ms-identity-redirect-handler/values.yaml
@@ -2,7 +2,7 @@ environment: dev
 replicas: 3
 
 container:
-  image: manicminer/ms-identity-redirect-handler
+  image: manicminer/ms-identity-redirect-handler:v0.1.1
   imagePullPolicy: Always
 
 secretStore:

--- a/pipelines/stages/install-helm-charts.yaml
+++ b/pipelines/stages/install-helm-charts.yaml
@@ -28,26 +28,7 @@ stages:
                       az aks install-cli
                       az aks get-credentials -n "$(kubernetesCluster)" -g "$(resourceGroupName)" --subscription "$(subscriptionName)"
                       kubelogin convert-kubeconfig -l azurecli
-                      az acr login --name "$(acrName)" --subscription "$(subscriptionName)"
-
-                # See https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration?pivots=nginx-ingress-controller
-                - task: AzureCLI@2
-                  displayName: Helm Install - app-routing-controller
-                  inputs:
-                    azureSubscription: $(serviceConnection)
-                    scriptType: bash
-                    scriptLocation: inlineScript
-                    inlineScript: |
-                      set -x
-                      helm upgrade \
-                        --install \
-                        --debug \
-                        --namespace app-routing-namespace \
-                        --create-namespace \
-                        --dependency-update \
-                        --timeout 2m \
-                        $(helmDryRun) \
-                        app-routing-controller ./helm-charts/app-routing-controller
+                      az acr login --name "$(acrName)" --subscription "$(subscriptionName)" || az acr check-health -n "$(acrName)" --yes
 
                 - task: AzureCLI@2
                   displayName: Helm Install - cert-manager
@@ -207,6 +188,43 @@ stages:
                         --repo "https://kedacore.github.io/charts"
 
                 - task: AzureCLI@2
+                  displayName: Helm Install - defra-certs
+                  inputs:
+                    azureSubscription: $(serviceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -x
+                      helm upgrade \
+                        --install \
+                        --debug \
+                        --namespace defra-certs \
+                        --create-namespace \
+                        --dependency-update \
+                        --timeout 2m \
+                        $(helmDryRun) \
+                        defra-certs ./helm-charts/defra-certs
+
+                # See https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration?pivots=nginx-ingress-controller
+                - task: AzureCLI@2
+                  displayName: Helm Install - app-routing-controller
+                  inputs:
+                    azureSubscription: $(serviceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -x
+                      helm upgrade \
+                        --install \
+                        --debug \
+                        --namespace app-routing-namespace \
+                        --create-namespace \
+                        --dependency-update \
+                        --timeout 2m \
+                        $(helmDryRun) \
+                        app-routing-controller ./helm-charts/app-routing-controller
+
+                - task: AzureCLI@2
                   displayName: Helm Install - ms-identity-redirect-handler
                   inputs:
                     azureSubscription: $(serviceConnection)
@@ -223,7 +241,6 @@ stages:
                         --timeout 2m \
                         $(helmDryRun) \
                         --set environment="${{ lower(parameters.environmentName) }}" \
-                        --set container.image="$(acrLoginServer)/manicminer/ms-identity-redirect-handler:v0.1.1" \
                         ms-identity-redirect-handler ./helm-charts/ms-identity-redirect-handler
 
 # vim: set ts=2 sts=2 sw=2 et:


### PR DESCRIPTION
- Source wildcard cert from CCoE KeyVault and store in the `defra-certs` namespace
- Configure the App Routing Controller (i.e. MS Nginx) to use it as the default TLS certificate, i.e. even when no ingresses match