### PR TITLE
Pin AKS ClI to avoid rate limits

### DIFF
--- a/pipelines/jobs/deploy-chart.yaml
+++ b/pipelines/jobs/deploy-chart.yaml
@@ -74,7 +74,7 @@ jobs:
           scriptLocation: inlineScript
           inlineScript: |
             set -x
-            az aks install-cli
+            az aks install-cli --client-version v1.36.1 --kubelogin-version v0.2.18
             az aks get-credentials -n "$(kubernetesCluster)" -g "$(resourceGroupName)" --subscription "$(subscriptionName)"
             kubelogin convert-kubeconfig -l azurecli
             az acr login --name "${ACR_NAME}" --subscription "$(subscriptionName)"

--- a/pipelines/stages/install-helm-charts.yaml
+++ b/pipelines/stages/install-helm-charts.yaml
@@ -25,7 +25,7 @@ stages:
                     scriptLocation: inlineScript
                     inlineScript: |
                       set -x
-                      az aks install-cli
+                      az aks install-cli --client-version v1.36.1 --kubelogin-version v0.2.18
                       az aks get-credentials -n "$(kubernetesCluster)" -g "$(resourceGroupName)" --subscription "$(subscriptionName)"
                       kubelogin convert-kubeconfig -l azurecli
                       az acr login --name "$(acrName)" --subscription "$(subscriptionName)" || az acr check-health -n "$(acrName)" --yes

--- a/scripts/pipeline/ensure-aso-managed-identity.sh
+++ b/scripts/pipeline/ensure-aso-managed-identity.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 : "${NAMESPACE:?NAMESPACE is required}"
 : "${OWNER_RESOURCE_GROUP_NAME:?OWNER_RESOURCE_GROUP_NAME is required}"
 
-az aks install-cli
+az aks install-cli --client-version v1.36.1 --kubelogin-version v0.2.18
 az aks get-credentials \
   --name "${AKS_NAME}" \
   --resource-group "${AKS_RESOURCE_GROUP_NAME}" \


### PR DESCRIPTION
releases/latest is a GitHub API endpoint:
```
https://api.github.com/repos/Azure/kubelogin/releases/latest
```
That is subject to GitHub API rate limits, especially for unauthenticated calls from shared CI agents.

Pinned releases/download/v0.2.18 is a direct release asset URL:
```
https://github.com/Azure/kubelogin/releases/download/v0.2.18/kubelogin.zip
```
That path does not require the API lookup for “what is latest?”, so it avoids the API rate limit failure you saw. It can still fail for general network/GitHub availability reasons, but it should not hit the unauthenticated GitHub API rate limit in the same way.

The pin fixes two things: removes the rate-limited latest lookup, and makes builds reproducible.
