### PR TITLE
Add `deployment.manifestTag` support across Helm charts

### DIFF
--- a/helm-charts/job/templates/cronjob.yaml
+++ b/helm-charts/job/templates/cronjob.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Values.service }}
   labels:
     {{- include "ipaffs-common.labels" . | nindent 4 }}
+    {{- if .Values.deployment.manifestTag }}
+    defra.gov.uk/manifest-tag: {{ .Values.deployment.manifestTag | quote }}
+    {{- end }}
 spec:
   schedule: {{ required "CronJob schedule is required" .Values.schedule | quote }}
   concurrencyPolicy: {{ default "Forbid" .Values.concurrencyPolicy }}

--- a/helm-charts/job/templates/scaledjob.yaml
+++ b/helm-charts/job/templates/scaledjob.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Values.service }}
   labels:
     {{- include "ipaffs-common.labels" . | nindent 4 }}
+    {{- if .Values.deployment.manifestTag }}
+    defra.gov.uk/manifest-tag: {{ .Values.deployment.manifestTag | quote }}
+    {{- end }}
   {{- if (default false .Values.suspend) }}
   annotations:
     autoscaling.keda.sh/paused: "true"

--- a/helm-charts/job/values.schema.json
+++ b/helm-charts/job/values.schema.json
@@ -15,6 +15,14 @@
     "imageRegistry": {
       "type": "string"
     },
+    "deployment": {
+      "type": "object",
+      "properties": {
+        "manifestTag": {
+          "type": "string"
+        }
+      }
+    },
     "externalSecret": {
       "type": "object",
       "required": [

--- a/helm-charts/job/values.yaml
+++ b/helm-charts/job/values.yaml
@@ -3,6 +3,9 @@ project: ipaffs
 environment: dev
 imageRegistry: ""
 
+deployment:
+  manifestTag: ""
+
 externalSecret:
   enabled: false
 

--- a/helm-charts/webapp/templates/deployment.yaml
+++ b/helm-charts/webapp/templates/deployment.yaml
@@ -15,6 +15,9 @@ metadata:
   name: {{ .Values.service }}
   labels:
     {{- include "ipaffs-common.labels" . | nindent 4 }}
+    {{- if .Values.deployment.manifestTag }}
+    defra.gov.uk/manifest-tag: {{ .Values.deployment.manifestTag | quote }}
+    {{- end }}
 spec:
   replicas: {{ .Values.container.replicas }}
   selector:

--- a/helm-charts/webapp/tests/deployment_test.yaml
+++ b/helm-charts/webapp/tests/deployment_test.yaml
@@ -42,6 +42,20 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: adds manifest tag to deployment metadata only
+    set:
+      service: test-service
+      azure.clientId: 00000000-0000-0000-0000-000000000001
+      container.image: test/image:1.0.0
+      deployment.manifestTag: 18.4.0
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.labels["defra.gov.uk/manifest-tag"]
+          value: 18.4.0
+      - notExists:
+          path: spec.template.metadata.labels["defra.gov.uk/manifest-tag"]
+
   - it: adds optional secret refs when redis service bus and external secrets are enabled
     set:
       service: test-service

--- a/helm-charts/webapp/values.schema.json
+++ b/helm-charts/webapp/values.schema.json
@@ -38,6 +38,14 @@
     "imageRegistry": {
       "type": "string"
     },
+    "deployment": {
+      "type": "object",
+      "properties": {
+        "manifestTag": {
+          "type": "string"
+        }
+      }
+    },
     "ingress": {
       "type": "object",
       "required": [

--- a/helm-charts/webapp/values.yaml
+++ b/helm-charts/webapp/values.yaml
@@ -10,6 +10,9 @@ container:
   command: ""
   args: []
 
+deployment:
+  manifestTag: ""
+
 ports:
   service: 80
   container: 8000

--- a/pipelines/jobs/deploy-chart.yaml
+++ b/pipelines/jobs/deploy-chart.yaml
@@ -106,12 +106,20 @@ jobs:
           MIGRATIONS_IMAGE: "ipaffs/${{ parameters.serviceName }}-configuration:${{ parameters.serviceVersion }}"
           NAMESPACE: ${{ parameters.namespace }}
           HELMFILE_SELECTOR: "${{ parameters.helmfileSelector }}"
+          SOURCE_REF: $(Build.SourceBranch)
         inputs:
           azureSubscription: $(serviceConnection)
           scriptType: bash
           scriptLocation: inlineScript
           inlineScript: |
             set -euo pipefail
+
+            manifest_tag=""
+            if [[ "${SOURCE_REF}" == refs/tags/* ]]; then
+              manifest_tag="${SOURCE_REF#refs/tags/}"
+            fi
+            export MANIFEST_TAG="${manifest_tag}"
+
             printenv
 
             curl -L https://github.com/helmfile/helmfile/releases/download/v1.1.9/helmfile_1.1.9_linux_amd64.tar.gz | tar -xz


### PR DESCRIPTION
- Introduced `manifestTag` to deployment metadata in `job` and `webapp` Helm charts.
- Added schema validations for the new field in `values.schema.json`.
- Updated deployment templates to conditionally include the `manifestTag`.
- Modified CI pipeline to export `manifestTag` from Git tags as `SOURCE_REF`.
