### PR TITLE
IST Remediation: explicitly disable privilege escalation where appropriate

### DIFF
--- a/helm-charts/job/templates/cronjob.yaml
+++ b/helm-charts/job/templates/cronjob.yaml
@@ -39,6 +39,10 @@ spec:
                 {{ end }}
               {{ end }}
               imagePullPolicy: {{ .Values.container.imagePullPolicy }}
+              {{- with .Values.container.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               envFrom:
                 - configMapRef:
                     name: ipaffs-config
@@ -67,6 +71,10 @@ spec:
             - name: {{ .Chart.Name }}-init
               image: "{{ include "job.image.resolve" (dict "root" . "image" .Values.initContainer.image) }}"
               command: {{ .Values.initContainer.command }}
+              {{- with .Values.initContainer.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
 {{- end }}
 {{- end }}
 

--- a/helm-charts/job/templates/scaledjob.yaml
+++ b/helm-charts/job/templates/scaledjob.yaml
@@ -42,6 +42,10 @@ spec:
               {{ end }}
             {{ end }}
             imagePullPolicy: {{ .Values.container.imagePullPolicy }}
+            {{- with .Values.container.securityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             envFrom:
               - configMapRef:
                   name: ipaffs-config
@@ -70,6 +74,10 @@ spec:
           - name: {{ .Chart.Name }}-init
             image: "{{ include "job.image.resolve" (dict "root" . "image" .Values.initContainer.image) }}"
             command: {{ .Values.initContainer.command }}
+            {{- with .Values.initContainer.securityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
 {{- end }}
   triggers:
     {{- required "keda.triggers must contain at least one trigger when keda.enabled is true" .Values.keda.triggers | toYaml | nindent 4 }}

--- a/helm-charts/job/values.yaml
+++ b/helm-charts/job/values.yaml
@@ -36,9 +36,13 @@ container:
   imagePullPolicy: Always
   command: ""
   args: []
+  securityContext:
+    allowPrivilegeEscalation: false
 
 initContainer:
   enabled: false
+  securityContext:
+    allowPrivilegeEscalation: false
 
 env: []
 

--- a/helm-charts/ms-identity-redirect-handler/templates/deployment.yaml
+++ b/helm-charts/ms-identity-redirect-handler/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
             {{- end }}
           {{- end }}
           imagePullPolicy: {{ .Values.container.imagePullPolicy }}
+          {{- with .Values.container.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8000

--- a/helm-charts/ms-identity-redirect-handler/values.yaml
+++ b/helm-charts/ms-identity-redirect-handler/values.yaml
@@ -4,6 +4,8 @@ replicas: 3
 container:
   image: manicminer/ms-identity-redirect-handler:v0.1.1
   imagePullPolicy: Always
+  securityContext:
+    allowPrivilegeEscalation: false
 
 secretStore:
   name: "external-secrets-azure-ccoe"

--- a/helm-charts/webapp/templates/deployment.yaml
+++ b/helm-charts/webapp/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
             {{- end }}
           {{- end }}
           imagePullPolicy: {{ .Values.container.imagePullPolicy }}
+          {{- with .Values.container.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: ipaffs-config
@@ -108,6 +112,10 @@ spec:
         - name: workload-identity-adal-bridge
           image: "manicminer/workload-identity-adal-bridge:0.4.1"
           restartPolicy: Always
+          {{- with .Values.initContainers.workloadIdentityAdalBridge.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: LOG_LEVEL
               value: "info"

--- a/helm-charts/webapp/tests/deployment_test.yaml
+++ b/helm-charts/webapp/tests/deployment_test.yaml
@@ -42,6 +42,17 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: disables privilege escalation on the app container
+    set:
+      service: test-service
+      azure.clientId: 00000000-0000-0000-0000-000000000001
+      container.image: test/image:1.0.0
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
   - it: adds manifest tag to deployment metadata only
     set:
       service: test-service
@@ -110,6 +121,9 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: workload-identity-adal-bridge
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
 
   - it: renders the adal bridge init container when managed and referenced databases are configured
     set:

--- a/helm-charts/webapp/values.yaml
+++ b/helm-charts/webapp/values.yaml
@@ -9,6 +9,13 @@ container:
   replicas: 1
   command: ""
   args: []
+  securityContext:
+    allowPrivilegeEscalation: false
+
+initContainers:
+  workloadIdentityAdalBridge:
+    securityContext:
+      allowPrivilegeEscalation: false
 
 deployment:
   manifestTag: ""


### PR DESCRIPTION
- Added `securityContext.allowPrivilegeEscalation: false` to containers and initContainers across `job`, `webapp`, and `ms-identity-redirect-handler` charts.
- Updated templates and tests to validate the new security setting.


See https://www.k8s.guide/security/sec-context/ for context
