### PR TITLE
Add PRE environment option to qa-automation run pipeline

### DIFF
--- a/pipelines/qa-automation.yaml
+++ b/pipelines/qa-automation.yaml
@@ -69,7 +69,9 @@ resources:
       type: github
       endpoint: DEFRA
       name: DEFRA/ipaffs-qa-automation
-      ref: refs/heads/main
+      # TEST ONLY: pinned to the 'pre' branch to validate the PRE environment option.
+      # Revert to refs/heads/main before merging.
+      ref: refs/heads/pre
 
 stages:
   - stage: RunTests

--- a/pipelines/qa-automation.yaml
+++ b/pipelines/qa-automation.yaml
@@ -14,6 +14,7 @@ parameters:
       - NEW-DEV
       - NEW-TST
       - NEW-PRD
+      - PRE
 
   - name: workers
     displayName: Workers


### PR DESCRIPTION
## What
Adds `PRE` to the **Environment** parameter (`environmentName`) of the qa-automation test-run pipeline so the suite can be run against the **pre** environment.

`PRE` flows through automatically:
- `QA_AUTOMATION_ENV: lower(PRE)` → container runs with `--env ENV=pre` (now supported by the qa-automation framework).
- Only `NEW-PRD` maps to `HigherEnvs`; `PRE` falls to `LowerEnvs`, so `qaAutomationKeyvaultName` resolves to the lower-env vault that already holds the `qa*` credentials.

## ⚠️ Contains a test-only commit
The second commit pins the `ipaffs-qa-automation` resource `ref` to the **`pre`** branch so this option can be validated end-to-end before the qa-automation `pre` branch is merged. **This commit must be reverted to `refs/heads/main` before merging this PR.**

## How to test
Run the **qa-automation-test-suite** pipeline selecting this branch as the pipeline version, with:
- **Environment** = `PRE`
- **Playwright Tag** = `@b2cNotifier` (only notifier-only tests are provisioned on pre)
- **Image Tag** = the image built from the qa-automation `pre` branch

## Notes
- Credentials come from the existing lower-env vault, so keep PRE runs to `@b2cNotifier` for now.
- Unrelated: the `DEFRA` service-connection error shown in the run dialog is a separate project-config issue and is not addressed here.