### PR TITLE
Update deploy-chart pipeline to handle branch-based manifest tagging

### DIFF
--- a/pipelines/jobs/deploy-chart.yaml
+++ b/pipelines/jobs/deploy-chart.yaml
@@ -118,9 +118,14 @@ jobs:
           inlineScript: |
             set -euo pipefail
 
-            manifest_tag=""
             if [[ "${SOURCE_REF}" == refs/tags/* ]]; then
               manifest_tag="${SOURCE_REF#refs/tags/}"
+            elif [[ "${SOURCE_REF}" == refs/heads/RELEASE/* ]]; then
+              manifest_tag="${SOURCE_REF#refs/heads/RELEASE/}"
+            elif [[ "${SOURCE_REF}" == refs/heads/* ]]; then
+              manifest_tag="${SOURCE_REF#refs/heads/}"
+            else
+              manifest_tag="${SOURCE_REF}"
             fi
             export MANIFEST_TAG="${manifest_tag}"
 


### PR DESCRIPTION
- Added logic to derive `manifest_tag` from `RELEASE/*` and other branch names.
