### PR TITLE
Add ama-metrics-settings configmap to expose deployment labels in Pro…

### DIFF
--- a/helm-charts/ama-metrics-settings/Chart.yaml
+++ b/helm-charts/ama-metrics-settings/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: ama-metrics-settings
+description: AMA metrics settings for Azure Managed Prometheus
+type: application
+version: 0.1.0

--- a/helm-charts/ama-metrics-settings/templates/configmap.yaml
+++ b/helm-charts/ama-metrics-settings/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ama-metrics-settings-configmap
+  namespace: kube-system
+data:
+  schema-version: v1
+  config-version: ver1
+  settings: |-
+    {
+      "default-targets-metrics-keep-list": {
+        "kube-state-metrics": "kube_deployment_labels|kube_pod_container_info|kube_deployment_created|kube_deployment_spec_replicas|kube_deployment_status_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_ready|kube_pod_container_status_ready|kube_pod_container_status_restarts_total|kube_pod_status_phase|kube_pod_status_ready|kube_node_status_condition|kube_node_status_allocatable"
+      }
+    }
+  ksm-config: |-
+    labels_allow_list:
+      deployments:
+        - "defra.gov.uk/manifest-tag"
+        - "app.kubernetes.io/name"

--- a/helm-charts/ama-metrics-settings/values.yaml
+++ b/helm-charts/ama-metrics-settings/values.yaml
@@ -1,0 +1,1 @@
+# No values needed - configmap is static

--- a/pipelines/stages/install-helm-charts.yaml
+++ b/pipelines/stages/install-helm-charts.yaml
@@ -265,4 +265,22 @@ stages:
                         --set environment="${{ lower(parameters.environmentName) }}" \
                         ms-identity-redirect-handler ./helm-charts/ms-identity-redirect-handler
 
+                - task: AzureCLI@2
+                  displayName: Helm Install - ama-metrics-settings
+                  inputs:
+                    azureSubscription: $(serviceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -x
+                      helm upgrade \
+                        --install \
+                        --debug \
+                        --namespace kube-system \
+                        --create-namespace \
+                        --dependency-update \
+                        --timeout 2m \
+                        $(helmDryRun) \
+                        ama-metrics-settings ./helm-charts/ama-metrics-settings
+
 # vim: set ts=2 sts=2 sw=2 et:


### PR DESCRIPTION
Ticket - https://eaflood.atlassian.net/browse/IMTA-21461
Create a Dashboard panel showing all installed App versions.

- from kubectl, we can print the release version, but grafana cannot see that - `kube_deployment_labels` `manifest-tag` is not exposed from the cluster. So we need to add a configmap to scrape the details. 

[Customize scraping of Prometheus metrics in Azure Monitor using ConfigMap - Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/prometheus-metrics-scrape-configuration)

- ADO Dry-run from Branch - https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1296056&view=logs&j=c4982056-ec32-5615-e2cf-3e2cf0746141&t=8a32e29c-8d14-5e23-f78c-959ef4b2166d