### PR TITLE
Ensure that each environment gets a unique access group for ACR, except for TST

### DIFF
--- a/pipelines/stages/entra-groups.yaml
+++ b/pipelines/stages/entra-groups.yaml
@@ -186,7 +186,7 @@ stages:
                 scriptPath: scripts/pipeline/remove-entra-group-members.sh
 
         - job: SaveTeamGroups
-          displayName: Update group variables
+          displayName: Update library variables
           condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
           dependsOn:
             - TeamGroups
@@ -357,7 +357,7 @@ stages:
                 scriptPath: scripts/pipeline/remove-entra-group-members.sh
 
         - job: SaveTeamGroups
-          displayName: Update group variables
+          displayName: Update library variables
           condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
           dependsOn:
             - TeamGroups
@@ -393,9 +393,10 @@ stages:
                   scripts/pipeline/update-group-variable.sh teamReadersGroupName '$(teamReadersDisplayName)'
 
 
-  - ${{ if or(eq(parameters.environmentName, 'DEV'), eq(parameters.environmentName, 'PRD')) }}:
-    - stage: CreateCommonAccessGroups
-      displayName: Create Common Entra Access Groups
+  # Note: TST and DEV share an access group for the ACR, since the ACR is shared between those environments
+  - ${{ if or(eq(parameters.environmentName, 'DEV'), eq(parameters.environmentName, 'PRE'), eq(parameters.environmentName, 'PRD')) }}:
+    - stage: CreateACRAccessGroups
+      displayName: Create ACR Entra Access Groups
       condition: and(not(failed()), not(canceled()))
       variables:
         - group: Common
@@ -457,17 +458,17 @@ stages:
                 scriptType: bash
                 scriptPath: scripts/pipeline/add-principal-to-group.sh
 
-        - job: SaveCommonGroups
-          displayName: Update group variables
+        - job: SaveACRAccessGroups
+          displayName: Update library variables
           condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
           dependsOn:
             - ACRGroups
           variables:
             - name: adoGroupName
-              ${{ if eq(parameters.environmentName, 'PRD') }}:
-                value: 'HigherEnvs'
+              ${{ if eq(parameters.environmentName, 'DEV') }}:
+                value: LowerEnvs
               ${{ else }}:
-                value: 'LowerEnvs'
+                value: ${{ parameters.environmentName }}
             - name: acrPullDisplayName
               value: $[dependencies.ACRGroups.outputs['AcrPull.displayName']]
             - name: acrPullObjectId
@@ -862,7 +863,7 @@ stages:
 
 
       - job: SaveAccessGroups
-        displayName: Update group variables
+        displayName: Update library variables
         condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         dependsOn:
           - DefraGroups


### PR DESCRIPTION

The "AcrPull" access group is used to grant the `AcrPull` data plane IAM role to any principal that needs it. The role is assigned to this group, and any members inherit it. These members can be added by later pipelines as needed, for example the `infra-permissions` pipeline stage.

Currently the main use for this is to ensure the system assigned managed identity for the Kubelet instances in each AKS cluster, is able to pull container images from the Azure Container Registry (ACR) for the corresponding environment.

We don't want kubelets to be able to authorize against ACR instances in other environments, with the exception of the TST cluster, which pulls images from the DEV registry.

This fix ensures that the correct groups are set up across all environments, and that the group details (it's displayName and object ID) are stored in the appropriate library variable group.

| Environment | Corresponding Cluster | ACR Used        | Entra Group Name          | Library Group |
| ----------- | --------------------- | --------------- | ------------------------- | ------------- |
| DEV         | DEVIMPINFAK1401       | DEVIMPINFAC1401 | AAG-Azure-IMP-DEV-AcrPull | LowerEnvs     |
| TST         | TSTIMPINFAK1401       | DEVIMPINFAC1401 | AAG-Azure-IMP-DEV-AcrPull | LowerEnvs     |
| PRE         | PREIMPINFAK1401       | PREIMPINFAC1401 | AAG-Azure-IMP-PRE-AcrPull | PRE           |
| PRD         | PRDIMPINFAK1401       | PRDIMPINFAC1401 | AAG-Azure-IMP-PRD-AcrPull | PRD           |