### PR TITLE
Bugfix: ensure correct service connection is used for ACR access groups, to align with group ownership

### DIFF
--- a/pipelines/stages/infra-permissions.yaml
+++ b/pipelines/stages/infra-permissions.yaml
@@ -64,7 +64,7 @@ stages:
                     GROUP_ID: $(acrPullGroupId)
                     PRINCIPAL_ID: $(aksKubeletPrincipalId)
                   inputs:
-                    azureSubscription: $(commonGroupsServiceConnection)
+                    azureSubscription: $(acrGroupsServiceConnection)
                     scriptType: bash
                     scriptPath: scripts/pipeline/add-principal-to-group.sh
 

--- a/pipelines/vars/dev.yaml
+++ b/pipelines/vars/dev.yaml
@@ -1,9 +1,9 @@
 ---
 variables:
+  acrGroupsServiceConnection: ADO-DefraGovUK-AZR-IMP-DEV1
   classicServiceConnection: ADO-DefraGovUK-AZR-IMP-SND1
   classicSqlAdminUserPrincipalObjectId: aaf71566-6255-442e-a51d-1633b56a01c2
   classicSubscriptionName: AZR-SND
-  commonGroupsServiceConnection: ADO-DefraGovUK-AZR-IMP-DEV1
   dnsResourceGroupName: DEVIMPZONRGP001
   dnsSubscriptionId: 20168d22-67f1-4cd0-bb56-3db91aec16ff # AZR-DEV
   entraAccessGroupBaseName: AAG-Azure-AZR_IMP_DEV1

--- a/pipelines/vars/prd.yaml
+++ b/pipelines/vars/prd.yaml
@@ -1,9 +1,9 @@
 ---
 variables:
+  acrGroupsServiceConnection: ADO-DefraGovUK-AZR-IMP-PRD1
   classicServiceConnection: ADO-DefraGovUK-AZR-PRD_IMP
   classicSqlAdminUserPrincipalObjectId: 1ad67fa9-a8aa-4b60-85ab-e6b684750c5a
   classicSubscriptionName: AZR-PRD
-  commonGroupsServiceConnection: ADO-DefraGovUK-AZR-IMP-PRD1
   dnsResourceGroupName: opsinfrgpzon001
   dnsSubscriptionId: fa6d4701-12be-41be-9c4d-ba3daf88ed8e # AZR-OPS
   entraAccessGroupBaseName: AAG-Azure-AZR_IMP_PRD1

--- a/pipelines/vars/pre.yaml
+++ b/pipelines/vars/pre.yaml
@@ -1,9 +1,9 @@
 ---
 variables:
+  acrGroupsServiceConnection: ADO-DefraGovUK-AZR-IMP-PRE1
   classicServiceConnection: ADO-DefraGovUK-AZR-PRE_IMP
   classicSqlAdminUserPrincipalObjectId: 3bc7291e-c9f1-4f90-8c9c-ad81fd5b727e
   classicSubscriptionName: AZR-PRE
-  commonGroupsServiceConnection: ADO-DefraGovUK-AZR-IMP-PRD1
   dnsResourceGroupName: OPSINFRGPZON001
   dnsSubscriptionId: fa6d4701-12be-41be-9c4d-ba3daf88ed8e # AZR-OPS
   entraAccessGroupBaseName: AAG-Azure-AZR_IMP_PRE1

--- a/pipelines/vars/tst.yaml
+++ b/pipelines/vars/tst.yaml
@@ -1,9 +1,9 @@
 ---
 variables:
+  acrGroupsServiceConnection: ADO-DefraGovUK-AZR-IMP-DEV1
   classicServiceConnection: ADO-DefraGovUK-AZR-IMP-TST1
   classicSqlAdminUserPrincipalObjectId: 8cb087fd-066a-44a7-9391-179898417544
   classicSubscriptionName: AZR-TST
-  commonGroupsServiceConnection: ADO-DefraGovUK-AZR-IMP-DEV1
   dnsResourceGroupName: TSTIMPZONRGP001
   dnsSubscriptionId: 00f1225e-37c2-4c7b-bc71-634164b667c6 # AZR-TST
   entraAccessGroupBaseName: AAG-Azure-AZR_IMP_TST1


### PR DESCRIPTION
Follows on from https://github.com/DEFRA/ipaffs-infra/pull/233