### PR TITLE
Jobs need `workload-identity-adal-bridge` to use MI

### DIFF
--- a/helm-charts/job/templates/cronjob.yaml
+++ b/helm-charts/job/templates/cronjob.yaml
@@ -1,4 +1,6 @@
 {{- if not (default false .Values.keda.enabled) }}
+{{- $database := default (dict) .Values.database }}
+{{- $databaseNames := get $database "databaseNames" | default (list) }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -21,10 +23,12 @@ spec:
         metadata:
           labels:
             {{- include "ipaffs-common.labels" . | nindent 12 }}
-          annotations:
             azure.workload.identity/use: "true"
         spec:
           serviceAccountName: {{ .Values.service }}-service
+{{- if gt (len $databaseNames) 0 }}
+          shareProcessNamespace: true
+{{- end }}
           restartPolicy: OnFailure
           containers:
             - name: {{ .Chart.Name }}
@@ -66,8 +70,17 @@ spec:
               resources:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
-{{- if .Values.initContainer.enabled }}
+{{- if or (gt (len $databaseNames) 0) .Values.initContainer.enabled }}
           initContainers:
+{{- if gt (len $databaseNames) 0 }}
+            - name: workload-identity-adal-bridge
+              image: "manicminer/workload-identity-adal-bridge:0.4.1"
+              restartPolicy: Always
+              env:
+                - name: LOG_LEVEL
+                  value: "info"
+{{- end }}
+{{- if .Values.initContainer.enabled }}
             - name: {{ .Chart.Name }}-init
               image: "{{ include "job.image.resolve" (dict "root" . "image" .Values.initContainer.image) }}"
               command: {{ .Values.initContainer.command }}
@@ -75,6 +88,7 @@ spec:
               securityContext:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/helm-charts/job/templates/scaledjob.yaml
+++ b/helm-charts/job/templates/scaledjob.yaml
@@ -1,4 +1,6 @@
 {{- if (default false .Values.keda.enabled) }}
+{{- $database := default (dict) .Values.database }}
+{{- $databaseNames := get $database "databaseNames" | default (list) }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
@@ -24,10 +26,12 @@ spec:
       metadata:
         labels:
           {{- include "ipaffs-common.labels" . | nindent 10 }}
-        annotations:
           azure.workload.identity/use: "true"
       spec:
         serviceAccountName: {{ .Values.service }}-service
+{{- if gt (len $databaseNames) 0 }}
+        shareProcessNamespace: true
+{{- end }}
         restartPolicy: OnFailure
         containers:
           - name: {{ .Chart.Name }}
@@ -69,8 +73,17 @@ spec:
             resources:
               {{- toYaml . | nindent 14 }}
             {{- end }}
-{{- if .Values.initContainer.enabled }}
+{{- if or (gt (len $databaseNames) 0) .Values.initContainer.enabled }}
         initContainers:
+{{- if gt (len $databaseNames) 0 }}
+          - name: workload-identity-adal-bridge
+            image: "manicminer/workload-identity-adal-bridge:0.4.1"
+            restartPolicy: Always
+            env:
+              - name: LOG_LEVEL
+                value: "info"
+{{- end }}
+{{- if .Values.initContainer.enabled }}
           - name: {{ .Chart.Name }}-init
             image: "{{ include "job.image.resolve" (dict "root" . "image" .Values.initContainer.image) }}"
             command: {{ .Values.initContainer.command }}
@@ -78,6 +91,7 @@ spec:
             securityContext:
               {{- toYaml . | nindent 14 }}
             {{- end }}
+{{- end }}
 {{- end }}
   triggers:
     {{- required "keda.triggers must contain at least one trigger when keda.enabled is true" .Values.keda.triggers | toYaml | nindent 4 }}

--- a/helm-charts/job/tests/cronjob_test.yaml
+++ b/helm-charts/job/tests/cronjob_test.yaml
@@ -1,0 +1,42 @@
+suite: cronjob template
+templates:
+  - templates/cronjob.yaml
+tests:
+  - it: renders workload identity bridge when databases are configured
+    set:
+      service: test-job
+      environment: dev
+      azure.clientId: 00000000-0000-0000-0000-000000000001
+      schedule: "30 23 * * *"
+      container.image: test/image:1.0.0
+      database.databaseNames[0]: imports
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.shareProcessNamespace
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: spec.jobTemplate.spec.template.metadata.annotations["azure.workload.identity/use"]
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].name
+          value: workload-identity-adal-bridge
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].image
+          value: manicminer/workload-identity-adal-bridge:0.4.1
+
+  - it: does not render workload identity bridge when no databases are configured
+    set:
+      service: test-job
+      environment: dev
+      azure.clientId: 00000000-0000-0000-0000-000000000001
+      schedule: "30 23 * * *"
+      container.image: test/image:1.0.0
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.initContainers
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.shareProcessNamespace

--- a/helm-charts/job/tests/scaledjob_test.yaml
+++ b/helm-charts/job/tests/scaledjob_test.yaml
@@ -1,0 +1,52 @@
+suite: scaledjob template
+templates:
+  - templates/scaledjob.yaml
+tests:
+  - it: renders workload identity bridge when databases are configured
+    set:
+      service: test-job
+      environment: dev
+      azure.clientId: 00000000-0000-0000-0000-000000000001
+      keda:
+        enabled: true
+        triggers:
+          - type: azure-servicebus
+            metadata:
+              queueName: test-queue
+      container.image: test/image:1.0.0
+      database.databaseNames[0]: imports
+    asserts:
+      - isKind:
+          of: ScaledJob
+      - equal:
+          path: spec.jobTargetRef.template.spec.shareProcessNamespace
+          value: true
+      - equal:
+          path: spec.jobTargetRef.template.metadata.labels["azure.workload.identity/use"]
+          value: "true"
+      - notExists:
+          path: spec.jobTargetRef.template.metadata.annotations["azure.workload.identity/use"]
+      - equal:
+          path: spec.jobTargetRef.template.spec.initContainers[0].name
+          value: workload-identity-adal-bridge
+      - equal:
+          path: spec.jobTargetRef.template.spec.initContainers[0].image
+          value: manicminer/workload-identity-adal-bridge:0.4.1
+
+  - it: does not render workload identity bridge when no databases are configured
+    set:
+      service: test-job
+      environment: dev
+      azure.clientId: 00000000-0000-0000-0000-000000000001
+      keda:
+        enabled: true
+        triggers:
+          - type: azure-servicebus
+            metadata:
+              queueName: test-queue
+      container.image: test/image:1.0.0
+    asserts:
+      - notExists:
+          path: spec.jobTargetRef.template.spec.initContainers
+      - notExists:
+          path: spec.jobTargetRef.template.spec.shareProcessNamespace


### PR DESCRIPTION
Add unit tests for `CronJob` and `ScaledJob` templates to verify workload identity bridge rendering conditions.
