### PR TITLE
IMTA-21510: log service status before test run 

### DIFF
--- a/pipelines/qa-automation.yaml
+++ b/pipelines/qa-automation.yaml
@@ -1,5 +1,5 @@
 ---
-name: ${{ parameters.environmentName }}-${{ parameters.imageTag }}-${{ replace(parameters.playwrightTag, '@', '') }}-$(Date:yyyyMMdd)$(Rev:.r)
+name: ${{ parameters.environmentName }}-${{ replace(replace(parameters.playwrightTag, '@', ''), ' ', '') }}-$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger: none
 pr: none

--- a/pipelines/qa-automation.yaml
+++ b/pipelines/qa-automation.yaml
@@ -1,4 +1,6 @@
 ---
+name: ${{ parameters.environmentName }}-${{ parameters.imageTag }}-${{ replace(parameters.playwrightTag, '@', '') }}-$(Date:yyyyMMdd)$(Rev:.r)
+
 trigger: none
 pr: none
 
@@ -14,6 +16,7 @@ parameters:
       - NEW-DEV
       - NEW-TST
       - NEW-PRD
+      - PRE
 
   - name: workers
     displayName: Workers
@@ -91,6 +94,22 @@ stages:
               workingDirectory: $(Pipeline.Workspace)/s/ipaffs-qa-automation
               inlineScript: |
                 $(Pipeline.Workspace)/s/ipaffs-infra/scripts/pipeline/substitute-environment-variables.sh .env-kv $(qaAutomationKeyvaultName) .env-substituted
+
+          - task: AzureCLI@2
+            displayName: Log IPAFFS service status (AKS)
+            continueOnError: true
+            inputs:
+              azureSubscription: ADO-DefraGovUK-AZR-IMP-${{ replace(upper(parameters.environmentName), 'NEW-', '') }}1
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                ENV="${{ replace(upper(parameters.environmentName), 'NEW-', '') }}"
+                az aks install-cli --client-version v1.36.1 --kubelogin-version v0.2.18
+                az aks get-credentials -n "${ENV}IMPINFAK1401" -g "${ENV}IMPINFRG1401" --subscription "AZR-IMP-${ENV}1" --overwrite-existing
+                kubelogin convert-kubeconfig -l azurecli
+                kubectl get deployments,cronjobs,scaledjobs -n "${ENV,,}" -L defra.gov.uk/manifest-tag
+                echo "--- Recent warnings ---"
+                kubectl get events -n "${ENV,,}" --field-selector type=Warning --sort-by=.lastTimestamp 2>/dev/null | tail -20
 
           - task: AzureCLI@2
             displayName: Run Automation Container


### PR DESCRIPTION
1. Log IPAFFS AKS service status (deployments, cronjobs, scaledjobs + manifest-tag and recent warning events) before the QA automation run, to give context when tests fail.
2. Add PRE to the environment options.
3. Set a descriptive pipeline run name (env-tag-date).

TST 
https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1302023&view=results
DEV
https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1302024&view=results

screenshots of the output

<img width="897" height="607" alt="image" src="https://github.com/user-attachments/assets/323a62e9-3ad4-444b-83ca-a55423e316d0" />


<img width="1206" height="433" alt="image" src="https://github.com/user-attachments/assets/d49d5962-5f5e-4377-a38b-41c9125ed357" />
