### PR TITLE
Pin subscription in Azure CLI task

### DIFF
--- a/pipelines/stages/configure-grafana.yaml
+++ b/pipelines/stages/configure-grafana.yaml
@@ -61,6 +61,10 @@ stages:
                     scriptLocation: inlineScript
                     inlineScript: |
                       set -euo pipefail
+                      # The service connection may default to a different subscription,
+                      # so pin the active subscription to this env's before any az call.
+                      az account set --subscription "$(subscriptionId)"
+                      az account show --query id -o tsv   # fail-fast: prove the sub
                       az extension add --name amg --yes --upgrade --only-show-errors
 
                       PROMETHEUS_NAME="$(prometheusName)"

--- a/pipelines/stages/deploy-grafana-dashboards.yaml
+++ b/pipelines/stages/deploy-grafana-dashboards.yaml
@@ -82,6 +82,10 @@ stages:
                     scriptType: bash
                     scriptLocation: inlineScript
                     inlineScript: |
+                      set -euo pipefail
+                      # SC may default to a different subscription; pin this env's first
+                      az account set --subscription "$(subscriptionId)"
+                      az account show --query id -o tsv   # fail-fast: prove the sub
                       az extension add --name amg --yes --upgrade --only-show-errors
 
                 - task: Bash@3
@@ -112,6 +116,9 @@ stages:
                     scriptLocation: inlineScript
                     inlineScript: |
                       set -euo pipefail
+                      # SC may default to a different subscription; pin this env's first
+                      az account set --subscription "$(subscriptionId)"
+                      az account show --query id -o tsv   # fail-fast: prove the sub
                       # Single source of truth for the deploy + datasource-injection
                       # logic; the same script can be run locally to test a dashboard.
                       GRAFANA_NAME="$(grafanaName)" \
@@ -132,6 +139,9 @@ stages:
                     scriptLocation: inlineScript
                     inlineScript: |
                       set -euo pipefail
+                      # SC may default to a different subscription; pin this env's first.
+                      az account set --subscription "$(subscriptionId)"
+                      az account show --query id -o tsv   # fail-fast: prove the sub
                       GRAFANA_NAME="$(grafanaName)"
                       RESOURCE_GROUP="$(resourceGroupName)"
                       ERRORS=0


### PR DESCRIPTION
Context : At least TST New stack ADO service connection is pointing to classic subscription AZR_TST, It causes monitoring pipeline to fail in TST env. https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1303046&view=results

Fix : set active subscription explicitly in AZR CLI task. 
Validated in DEV : https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1303142&view=results