### PR TITLE
disable acr public access

### DIFF
--- a/bicep/modules/acr.bicep
+++ b/bicep/modules/acr.bicep
@@ -18,6 +18,7 @@ resource acr 'Microsoft.ContainerRegistry/registries@2025-04-01' = {
 
   properties: {
     adminUserEnabled: acrParams.adminEnabled
+    publicNetworkAccess: 'Disabled'
   }
 }
 


### PR DESCRIPTION
This PR is to disable ACR public network access.
ADO run: https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1306721&view=logs&j=9c424e97-af58-56bf-770b-0f5e34f32769&t=1478396a-d29a-5913-b89c-26aadf34ebe6

What-If:
The deployment will update the following scope:

Scope: /subscriptions/f27f4f47-2766-40c8-8450-f585675f76a2/resourceGroups/devimpinfrg1401

  ~ Microsoft.ContainerRegistry/registries/DEVIMPINFAC1401 [2025-04-01]
    - properties.dataEndpointEnabled: false
    - properties.encryption:

        status: "disabled"

    ~ properties.publicNetworkAccess: "Enabled" => "Disabled"
    ~ tags.CreatedDate:               "2026-07-02" => "[utcNow('yyyy-MM-dd')]"


