### PR TITLE
remove acr service endpoints from all envs

### DIFF
--- a/bicep/envs/dev/20-network.bicepparam
+++ b/bicep/envs/dev/20-network.bicepparam
@@ -264,9 +264,6 @@ param vnetParams = {
       ]
       serviceEndpoints: [
         {
-          service: 'Microsoft.ContainerRegistry'
-        }
-        {
           service: 'Microsoft.KeyVault'
         }
         {
@@ -282,9 +279,6 @@ param vnetParams = {
       addressPrefix: '10.179.144.16/28'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.ContainerRegistry'
-        }
         {
           service: 'Microsoft.KeyVault'
         }
@@ -331,9 +325,6 @@ param vnetParams = {
       addressPrefix: '10.179.146.0/24'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.ContainerRegistry'
-        }
         {
           service: 'Microsoft.KeyVault'
         }

--- a/bicep/envs/prd/20-network.bicepparam
+++ b/bicep/envs/prd/20-network.bicepparam
@@ -263,9 +263,6 @@ param vnetParams = {
       ]
       serviceEndpoints: [
         {
-          service: 'Microsoft.ContainerRegistry'
-        }
-        {
           service: 'Microsoft.KeyVault'
         }
         {
@@ -281,9 +278,6 @@ param vnetParams = {
       addressPrefix: '10.179.140.16/28'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.ContainerRegistry'
-        }
         {
           service: 'Microsoft.KeyVault'
         }
@@ -330,9 +324,6 @@ param vnetParams = {
       addressPrefix: '10.179.142.0/24'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.ContainerRegistry'
-        }
         {
           service: 'Microsoft.KeyVault'
         }

--- a/bicep/envs/pre/20-network.bicepparam
+++ b/bicep/envs/pre/20-network.bicepparam
@@ -263,9 +263,6 @@ param vnetParams = {
       ]
       serviceEndpoints: [
         {
-          service: 'Microsoft.ContainerRegistry'
-        }
-        {
           service: 'Microsoft.KeyVault'
         }
         {
@@ -281,9 +278,6 @@ param vnetParams = {
       addressPrefix: '10.179.136.16/28'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.ContainerRegistry'
-        }
         {
           service: 'Microsoft.KeyVault'
         }
@@ -330,9 +324,6 @@ param vnetParams = {
       addressPrefix: '10.179.138.0/24'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.ContainerRegistry'
-        }
         {
           service: 'Microsoft.KeyVault'
         }

--- a/bicep/envs/tst/20-network.bicepparam
+++ b/bicep/envs/tst/20-network.bicepparam
@@ -261,9 +261,6 @@ param vnetParams = {
       ]
       serviceEndpoints: [
         {
-          service: 'Microsoft.ContainerRegistry'
-        }
-        {
           service: 'Microsoft.KeyVault'
         }
         {
@@ -279,9 +276,6 @@ param vnetParams = {
       addressPrefix: '10.179.132.16/28'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.ContainerRegistry'
-        }
         {
           service: 'Microsoft.KeyVault'
         }
@@ -328,9 +322,6 @@ param vnetParams = {
       addressPrefix: '10.179.134.0/24'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.ContainerRegistry'
-        }
         {
           service: 'Microsoft.KeyVault'
         }


### PR DESCRIPTION
This PR removes the KV service endpoints from 3 AKS subnets in each environment.

[Pipeline Link](https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1306754&view=logs&j=263e7a41-f1ab-5de5-9a03-2e7ab32d25f6&t=cc46e084-bad0-530d-4fe2-941df9f93101)

What-If: 
2026-07-07T05:39:47.8523730Z     ~ properties.subnets: [
2026-07-07T05:39:47.8524016Z       ~ 0:
2026-07-07T05:39:47.8524157Z 
2026-07-07T05:39:47.8524491Z         ~ properties.serviceEndpoints: [
2026-07-07T05:39:47.8524880Z           - 0:
2026-07-07T05:39:47.8524976Z 
2026-07-07T05:39:47.8525186Z               service: "Microsoft.ContainerRegistry"
2026-07-07T05:39:47.8525288Z 
2026-07-07T05:39:47.8525469Z           ]
2026-07-07T05:39:47.8525573Z 
2026-07-07T05:39:47.8525757Z       ~ 1:
2026-07-07T05:39:47.8525927Z 
2026-07-07T05:39:47.8526127Z         ~ properties.serviceEndpoints: [
2026-07-07T05:39:47.8526341Z           - 0:
2026-07-07T05:39:47.8526497Z 
2026-07-07T05:39:47.8526690Z               service: "Microsoft.ContainerRegistry"
2026-07-07T05:39:47.8526824Z 
2026-07-07T05:39:47.8526990Z           ]
2026-07-07T05:39:47.8527101Z 
2026-07-07T05:39:47.8527266Z       ~ 5:
2026-07-07T05:39:47.8527374Z 
2026-07-07T05:39:47.8527569Z         ~ properties.serviceEndpoints: [
2026-07-07T05:39:47.8527798Z           - 0:
2026-07-07T05:39:47.8527900Z 
2026-07-07T05:39:47.8528124Z               service: "Microsoft.ContainerRegistry"
2026-07-07T05:39:47.8528347Z 
2026-07-07T05:39:47.8528560Z           ]
