### PR TITLE
remove kv service endpoints from all envs

### DIFF
--- a/bicep/envs/dev/20-network.bicepparam
+++ b/bicep/envs/dev/20-network.bicepparam
@@ -264,9 +264,6 @@ param vnetParams = {
       ]
       serviceEndpoints: [
         {
-          service: 'Microsoft.KeyVault'
-        }
-        {
           service: 'Microsoft.ServiceBus'
         }
       ]
@@ -279,9 +276,6 @@ param vnetParams = {
       addressPrefix: '10.179.144.16/28'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.KeyVault'
-        }
         {
           service: 'Microsoft.ServiceBus'
         }
@@ -325,9 +319,6 @@ param vnetParams = {
       addressPrefix: '10.179.146.0/24'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.KeyVault'
-        }
         {
           service: 'Microsoft.ServiceBus'
         }

--- a/bicep/envs/prd/20-network.bicepparam
+++ b/bicep/envs/prd/20-network.bicepparam
@@ -263,9 +263,6 @@ param vnetParams = {
       ]
       serviceEndpoints: [
         {
-          service: 'Microsoft.KeyVault'
-        }
-        {
           service: 'Microsoft.ServiceBus'
         }
       ]
@@ -278,9 +275,6 @@ param vnetParams = {
       addressPrefix: '10.179.140.16/28'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.KeyVault'
-        }
         {
           service: 'Microsoft.ServiceBus'
         }
@@ -324,9 +318,6 @@ param vnetParams = {
       addressPrefix: '10.179.142.0/24'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.KeyVault'
-        }
         {
           service: 'Microsoft.ServiceBus'
         }

--- a/bicep/envs/pre/20-network.bicepparam
+++ b/bicep/envs/pre/20-network.bicepparam
@@ -263,9 +263,6 @@ param vnetParams = {
       ]
       serviceEndpoints: [
         {
-          service: 'Microsoft.KeyVault'
-        }
-        {
           service: 'Microsoft.ServiceBus'
         }
       ]
@@ -278,9 +275,6 @@ param vnetParams = {
       addressPrefix: '10.179.136.16/28'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.KeyVault'
-        }
         {
           service: 'Microsoft.ServiceBus'
         }
@@ -324,9 +318,6 @@ param vnetParams = {
       addressPrefix: '10.179.138.0/24'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.KeyVault'
-        }
         {
           service: 'Microsoft.ServiceBus'
         }

--- a/bicep/envs/tst/20-network.bicepparam
+++ b/bicep/envs/tst/20-network.bicepparam
@@ -261,9 +261,6 @@ param vnetParams = {
       ]
       serviceEndpoints: [
         {
-          service: 'Microsoft.KeyVault'
-        }
-        {
           service: 'Microsoft.ServiceBus'
         }
       ]
@@ -276,9 +273,6 @@ param vnetParams = {
       addressPrefix: '10.179.132.16/28'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.KeyVault'
-        }
         {
           service: 'Microsoft.ServiceBus'
         }
@@ -322,9 +316,6 @@ param vnetParams = {
       addressPrefix: '10.179.134.0/24'
       delegations: []
       serviceEndpoints: [
-        {
-          service: 'Microsoft.KeyVault'
-        }
         {
           service: 'Microsoft.ServiceBus'
         }


### PR DESCRIPTION
This PR is for removing kv service endpoints from 3 AKS subnets in all environment.

[ADO Pipeline Link](https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1306780&view=logs&j=263e7a41-f1ab-5de5-9a03-2e7ab32d25f6&t=cc46e084-bad0-530d-4fe2-941df9f93101)

What-If:
~ properties.subnets: [
  ~ 0:  → properties.serviceEndpoints: [ - 1: service: "Microsoft.KeyVault" ]
  ~ 1:  → properties.serviceEndpoints: [ - 1: service: "Microsoft.KeyVault" ]
  ~ 5:  → properties.serviceEndpoints: [ - 1: service: "Microsoft.KeyVault" ]
]