### PR TITLE
IaC Grafana role assignments to users and ADO SP 

### DIFF
--- a/bicep/40-infra.bicep
+++ b/bicep/40-infra.bicep
@@ -9,6 +9,7 @@ param classicResourceIds object
 param entraGroups object
 param subnets object
 param tenantId string
+param deployServicePrincipalObjectId string
 param vnetName string
 
 param createdDate string = utcNow('yyyy-MM-dd')
@@ -152,6 +153,8 @@ module monitoring './modules/monitoring.bicep' = {
     location: location
     tags: tags
     monitoringParams: monitoringParams
+    entraGroups: entraGroups
+    deployServicePrincipalObjectId: deployServicePrincipalObjectId
   }
 }
 

--- a/bicep/envs/dev/40-infra.bicepparam
+++ b/bicep/envs/dev/40-infra.bicepparam
@@ -11,6 +11,7 @@ param entraGroups = {}
 param environment = 'DEV'
 param subnets = {}
 param tenantId = ''
+param deployServicePrincipalObjectId = ''
 param vnetName = 'DEVIMPNETVN1401'
 
 param aksParams = {

--- a/bicep/envs/prd/40-infra.bicepparam
+++ b/bicep/envs/prd/40-infra.bicepparam
@@ -11,6 +11,7 @@ param entraGroups = {}
 param environment = 'PRD'
 param subnets = {}
 param tenantId = ''
+param deployServicePrincipalObjectId = ''
 param vnetName = 'PRDIMPNETVN1401'
 
 param aksParams = {

--- a/bicep/envs/pre/40-infra.bicepparam
+++ b/bicep/envs/pre/40-infra.bicepparam
@@ -11,6 +11,7 @@ param entraGroups = {}
 param environment = 'PRE'
 param subnets = {}
 param tenantId = ''
+param deployServicePrincipalObjectId = ''
 param vnetName = 'PREIMPNETVN1401'
 
 param aksParams = {

--- a/bicep/envs/tst/40-infra.bicepparam
+++ b/bicep/envs/tst/40-infra.bicepparam
@@ -11,6 +11,7 @@ param entraGroups = {}
 param environment = 'TST'
 param subnets = {}
 param tenantId = ''
+param deployServicePrincipalObjectId = ''
 param vnetName = 'TSTIMPNETVN1401'
 
 param aksParams = {

--- a/bicep/modules/grafana-role-assignment.bicep
+++ b/bicep/modules/grafana-role-assignment.bicep
@@ -1,0 +1,21 @@
+targetScope = 'resourceGroup'
+
+param grafanaName string
+param deploymentId string
+param principalObjectId string
+param principalType string
+param roleDefinitionId string
+
+resource grafana 'Microsoft.Dashboard/grafana@2025-08-01' existing = {
+  name: grafanaName
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(grafana.id, roleDefinitionId, principalObjectId)
+  scope: grafana
+  properties: {
+    principalId: principalObjectId
+    principalType: principalType
+    roleDefinitionId: roleDefinitionId
+  }
+}

--- a/bicep/modules/monitoring.bicep
+++ b/bicep/modules/monitoring.bicep
@@ -1,12 +1,19 @@
 targetScope = 'resourceGroup'
 
 param monitoringParams object
+param entraGroups object
+param deployServicePrincipalObjectId string
 param deploymentId string
 param location string
 param tags object
 
 var monitoringReaderRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')
 var monitoringDataReaderRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b0d8363b-8ddd-447d-831f-62ca05bff136')
+
+// Azure Managed Grafana built-in roles for the tenant
+var grafanaAdminRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '22926164-76b3-42b3-bc55-97df8dab3e41')
+var grafanaEditorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a79a5197-3a5c-4973-a920-486035ffd60f')
+var grafanaViewerRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '60921a7e-fef1-4a43-9b16-a26c52ad4769')
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2025-07-01' = {
   name: monitoringParams.logAnalyticsName
@@ -60,7 +67,59 @@ resource grafanaAdminRole 'Microsoft.Authorization/roleAssignments@2022-04-01' =
   properties: {
     principalId: monitoringParams.principalObjectId
     principalType: 'Group'
-    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', '22926164-76b3-42b3-bc55-97df8dab3e41')
+    roleDefinitionId: grafanaAdminRoleId
+  }
+}
+
+// Team group Grafana access mapping : ProjAdmins -> Admin, Developers ->
+// Editor, Readers -> Viewer (groups created + populated by entra-groups.yaml).
+module grafanaAdmins './grafana-role-assignment.bicep' = {
+  name: 'grafanaAdmins-${deploymentId}'
+  scope: resourceGroup()
+  params: {
+    grafanaName: grafanaDashboard.name
+    deploymentId: deploymentId
+    principalObjectId: entraGroups.grafanaAdmins.id
+    principalType: 'Group'
+    roleDefinitionId: grafanaAdminRoleId
+  }
+}
+
+module grafanaEditors './grafana-role-assignment.bicep' = {
+  name: 'grafanaEditors-${deploymentId}'
+  scope: resourceGroup()
+  params: {
+    grafanaName: grafanaDashboard.name
+    deploymentId: deploymentId
+    principalObjectId: entraGroups.grafanaEditors.id
+    principalType: 'Group'
+    roleDefinitionId: grafanaEditorRoleId
+  }
+}
+
+module grafanaViewers './grafana-role-assignment.bicep' = {
+  name: 'grafanaViewers-${deploymentId}'
+  scope: resourceGroup()
+  params: {
+    grafanaName: grafanaDashboard.name
+    deploymentId: deploymentId
+    principalObjectId: entraGroups.grafanaViewers.id
+    principalType: 'Group'
+    roleDefinitionId: grafanaViewerRoleId
+  }
+}
+
+// Deploy service principal (ADO service connection) needs Grafana Admin directly
+// to manage dashboards and datasources
+module grafanaDeploySpAdmin './grafana-role-assignment.bicep' = {
+  name: 'grafanaDeploySpAdmin-${deploymentId}'
+  scope: resourceGroup()
+  params: {
+    grafanaName: grafanaDashboard.name
+    deploymentId: deploymentId
+    principalObjectId: deployServicePrincipalObjectId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: grafanaAdminRoleId
   }
 }
 
@@ -90,4 +149,3 @@ output logAnalyticsId string = logAnalytics.id
 output grafanaManagedIdentityPrincipalId string = grafanaDashboard.identity.principalId
 output grafanaName string = grafanaDashboard.name
 output prometheusName string = prometheus.name
-

--- a/pipelines/stages/deploy-bicep-infra.yaml
+++ b/pipelines/stages/deploy-bicep-infra.yaml
@@ -65,6 +65,18 @@ stages:
                     id: '$(searchReadersGroupId)'
                     name: '$(searchReadersGroupName)'
                   }
+                  grafanaAdmins: {
+                    id: '$(grafanaAdminsGroupId)'
+                    name: '$(grafanaAdminsGroupName)'
+                  }
+                  grafanaEditors: {
+                    id: '$(grafanaEditorsGroupId)'
+                    name: '$(grafanaEditorsGroupName)'
+                  }
+                  grafanaViewers: {
+                    id: '$(grafanaViewersGroupId)'
+                    name: '$(grafanaViewersGroupName)'
+                  }
                   blobStorageContributors: {
                     id: '$(blobStorageContributorsGroupId)'
                     name: '$(blobStorageContributorsGroupName)'
@@ -153,7 +165,8 @@ stages:
                         --resource-group $(resourceGroupName) \
                         --template-file bicep/40-infra.bicep \
                         --parameters bicep/40-infra-runtime.bicepparam \
-                        --parameters tenantId="$(tenantId)"
+                        --parameters tenantId="$(tenantId)" \
+                        --parameters deployServicePrincipalObjectId="$(serviceConnectionPrincipalId)"
 
                 - task: AzureCLI@2
                   displayName: Deploy - Infrastructure
@@ -170,7 +183,8 @@ stages:
                         --resource-group $(resourceGroupName) \
                         --template-file bicep/40-infra.bicep \
                         --parameters bicep/40-infra-runtime.bicepparam \
-                        --parameters tenantId="$(tenantId)"
+                        --parameters tenantId="$(tenantId)" \
+                        --parameters deployServicePrincipalObjectId="$(serviceConnectionPrincipalId)"
 
                 - task: AzureCLI@2
                   displayName: Wait for Deployment - Infrastructure

--- a/pipelines/stages/entra-groups.yaml
+++ b/pipelines/stages/entra-groups.yaml
@@ -746,6 +746,84 @@ stages:
               scriptType: bash
               scriptPath: scripts/pipeline/add-principal-to-group.sh
 
+      - job: GrafanaGroups
+        displayName: Grafana Groups
+        condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+        steps:
+          - checkout: self
+
+          - task: AzureCLI@2
+            name: GrafanaAdmins
+            env:
+              GROUP_NAME: $(entraAccessGroupBaseName)-GrafanaAdmin
+              GROUP_DESCRIPTION: Entra access group for IPAFFS Grafana Admins in ${{ parameters.environmentName }} environment
+              GROUP_OWNER_OBJECT_IDS: >
+                $(serviceConnectionPrincipalId)
+                $(upstreamServiceConnectionPrincipalId)
+            inputs:
+              azureSubscription: $(upstreamServiceConnection)
+              scriptType: bash
+              scriptPath: scripts/pipeline/create-entra-group.sh
+
+          - task: AzureCLI@2
+            name: GrafanaAdminsMembersAdmins
+            env:
+              GROUP_ID: $(GrafanaAdmins.objectId)
+              PRINCIPAL_ID: $(teamAdminsGroupId)
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptPath: scripts/pipeline/add-principal-to-group.sh
+
+          - task: AzureCLI@2
+            name: GrafanaEditors
+            env:
+              GROUP_NAME: $(entraAccessGroupBaseName)-GrafanaEditor
+              GROUP_DESCRIPTION: Entra access group for IPAFFS Grafana Editors in ${{ parameters.environmentName }} environment
+              GROUP_OWNER_OBJECT_IDS: >
+                $(serviceConnectionPrincipalId)
+                $(upstreamServiceConnectionPrincipalId)
+            inputs:
+              azureSubscription: $(upstreamServiceConnection)
+              scriptType: bash
+              scriptPath: scripts/pipeline/create-entra-group.sh
+
+          # Developers map to Grafana Editor in lower environments only (mirrors
+          # Search Contributors); higher envs get no Developer nesting.
+          - ${{ if and(ne(parameters.environmentName, 'PRE'), ne(parameters.environmentName, 'PRD')) }}:
+            - task: AzureCLI@2
+              name: GrafanaEditorsMembersDevelopers
+              env:
+                GROUP_ID: $(GrafanaEditors.objectId)
+                PRINCIPAL_ID: $(teamDevelopersGroupId)
+              inputs:
+                azureSubscription: $(serviceConnection)
+                scriptType: bash
+                scriptPath: scripts/pipeline/add-principal-to-group.sh
+
+          - task: AzureCLI@2
+            name: GrafanaViewers
+            env:
+              GROUP_NAME: $(entraAccessGroupBaseName)-GrafanaViewer
+              GROUP_DESCRIPTION: Entra access group for IPAFFS Grafana Viewers in ${{ parameters.environmentName }} environment
+              GROUP_OWNER_OBJECT_IDS: >
+                $(serviceConnectionPrincipalId)
+                $(upstreamServiceConnectionPrincipalId)
+            inputs:
+              azureSubscription: $(upstreamServiceConnection)
+              scriptType: bash
+              scriptPath: scripts/pipeline/create-entra-group.sh
+
+          - task: AzureCLI@2
+            name: GrafanaViewersMembersReaders
+            env:
+              GROUP_ID: $(GrafanaViewers.objectId)
+              PRINCIPAL_ID: $(teamReadersGroupId)
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: bash
+              scriptPath: scripts/pipeline/add-principal-to-group.sh
+
       - job: StorageGroups
         displayName: Storage Account Groups
         condition: and(not(failed()), not(canceled()), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
@@ -870,6 +948,7 @@ stages:
           - AksGroups
           - KeyVaultGroups
           - SearchGroups
+          - GrafanaGroups
           - StorageGroups
           - SQLGroups
         variables:
@@ -913,6 +992,18 @@ stages:
             value: $[dependencies.SearchGroups.outputs['SearchReaders.displayName']]
           - name: searchReadersObjectId
             value: $[dependencies.SearchGroups.outputs['SearchReaders.objectId']]
+          - name: grafanaAdminsDisplayName
+            value: $[dependencies.GrafanaGroups.outputs['GrafanaAdmins.displayName']]
+          - name: grafanaAdminsObjectId
+            value: $[dependencies.GrafanaGroups.outputs['GrafanaAdmins.objectId']]
+          - name: grafanaEditorsDisplayName
+            value: $[dependencies.GrafanaGroups.outputs['GrafanaEditors.displayName']]
+          - name: grafanaEditorsObjectId
+            value: $[dependencies.GrafanaGroups.outputs['GrafanaEditors.objectId']]
+          - name: grafanaViewersDisplayName
+            value: $[dependencies.GrafanaGroups.outputs['GrafanaViewers.displayName']]
+          - name: grafanaViewersObjectId
+            value: $[dependencies.GrafanaGroups.outputs['GrafanaViewers.objectId']]
           - name: blobStorageContributorsDisplayName
             value: $[dependencies.StorageGroups.outputs['BlobStorageContributors.displayName']]
           - name: blobStorageContributorsObjectId
@@ -957,6 +1048,12 @@ stages:
                 scripts/pipeline/update-group-variable.sh searchContributorsGroupName '$(searchContributorsDisplayName)'
                 scripts/pipeline/update-group-variable.sh searchReadersGroupId '$(searchReadersObjectId)'
                 scripts/pipeline/update-group-variable.sh searchReadersGroupName '$(searchReadersDisplayName)'
+                scripts/pipeline/update-group-variable.sh grafanaAdminsGroupId '$(grafanaAdminsObjectId)'
+                scripts/pipeline/update-group-variable.sh grafanaAdminsGroupName '$(grafanaAdminsDisplayName)'
+                scripts/pipeline/update-group-variable.sh grafanaEditorsGroupId '$(grafanaEditorsObjectId)'
+                scripts/pipeline/update-group-variable.sh grafanaEditorsGroupName '$(grafanaEditorsDisplayName)'
+                scripts/pipeline/update-group-variable.sh grafanaViewersGroupId '$(grafanaViewersObjectId)'
+                scripts/pipeline/update-group-variable.sh grafanaViewersGroupName '$(grafanaViewersDisplayName)'
                 scripts/pipeline/update-group-variable.sh blobStorageContributorsGroupId '$(blobStorageContributorsObjectId)'
                 scripts/pipeline/update-group-variable.sh blobStorageContributorsGroupName '$(blobStorageContributorsDisplayName)'
                 scripts/pipeline/update-group-variable.sh blobStorageReadersGroupId '$(blobStorageReadersObjectId)'


### PR DESCRIPTION
Grants Azure Managed Grafana roles to Users and ADO Service Principal through Infrastructure-as-Code

Brief description of updates:
1.pipelines/stages/entra-groups.yaml :  
a) Creates 3 Grafana groups via GrafanaGroups job  and nests team groups under it using existing create-entra-group.sh and add-principal-to-group.sh.
b) Publishes the ids into the per-env library variable group in SaveAccessGroups job

2.pipelines/stages/deploy-bicep-infra.yaml : GenerateBicepParams writes grafanaAdmins/Editors/Viewers into the entraGroups object of the generated 40-infra-runtime.bicepparam

3.bicep/40-infra.bicep:  passes entraGroups + the SP id into the monitoring module.

4.monitoring.bicep: adds Grafana Admin/Editor/Viewer role vars and four role assignments (3 groups + SP)

5.New : modules/grafana-role-assignment.bicep :  reusable assignment module scoped to the Grafana instance( same as Azure search ) 


Validation: 
https://dev.azure.com/defragovuk/DEFRA-EUTD-IPAFFS/_build/results?buildId=1306903&view=logs&j=ee7f8ef8-a84d-5445-f692-b0d17e80d15e&t=dc5e99da-7bab-512a-fdf8-ea8b0caf89e6 