### PR TITLE
Feature/imta 20995 privatelink subnet policy

### DIFF
--- a/bicep/20-network.bicep
+++ b/bicep/20-network.bicep
@@ -29,6 +29,17 @@ module nsg './modules/network-security-groups.bicep' = {
   }
 }
 
+module routeTable './modules/route-table.bicep' = {
+  name: 'route-table-${deploymentId}'
+  scope: resourceGroup()
+  params: {
+    name: vnetParams.routeTable.name
+    location: location
+    tags: tags
+    virtualApplianceIp: vnetParams.routeTable.virtualApplianceIp
+  }
+}
+
 module vnet './modules/virtual-network.bicep' = {
   name: 'vnet-${deploymentId}'
   scope: resourceGroup()
@@ -38,6 +49,7 @@ module vnet './modules/virtual-network.bicep' = {
     location: location
     tags: tags
     vnetParams: vnetParams
+    routeTableId: routeTable.outputs.resourceId
   }
   dependsOn: [
     nsg

--- a/bicep/modules/route-table.bicep
+++ b/bicep/modules/route-table.bicep
@@ -1,0 +1,28 @@
+targetScope = 'resourceGroup'
+
+param name string
+param location string
+param tags object
+param virtualApplianceIp string
+
+resource routeTable 'Microsoft.Network/routeTables@2025-05-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    disableBgpRoutePropagation: true
+    routes: [
+      {
+        name: 'Default'
+        properties: {
+          addressPrefix: '0.0.0.0/0'
+          nextHopType: 'VirtualAppliance'
+          nextHopIpAddress: virtualApplianceIp
+        }
+      }
+    ]
+  }
+}
+
+output resourceId string = routeTable.id
+output name string = routeTable.name

--- a/bicep/modules/virtual-network.bicep
+++ b/bicep/modules/virtual-network.bicep
@@ -12,6 +12,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   location: location
   tags: tags
   properties: {
+    privateEndpointVNetPolicies: 'Disabled'
     addressSpace: {
       addressPrefixes: vnetParams.addressPrefixes
     }
@@ -24,7 +25,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
         addressPrefix: subnet.addressPrefix
         delegations: subnet.?delegations ?? []
         serviceEndpoints: subnet.?serviceEndpoints ?? []
-        privateEndpointNetworkPolicies: subnet.?privateEndpointNetworkPolicies ?? 'Enabled'
+        privateEndpointNetworkPolicies: subnet.?privateEndpointNetworkPolicies ?? 'Disabled'
         privateLinkServiceNetworkPolicies: subnet.?privateLinkServiceNetworkPolicies ?? 'Enabled'
         routeTable: {
           id: subnet.?routeTableId ?? routeTableId
@@ -51,7 +52,7 @@ module vnetNetworkContributor './vnet-role-assignment.bicep' = [for principalId 
   dependsOn: [virtualNetwork]
 }]
 
-output subnetIds array = [for subnet in virtualNetwork.properties.subnets: subnet.id]
+output subnetIds array = [for subnet in vnetParams.subnets: resourceId('Microsoft.Network/virtualNetworks/subnets', vnetParams.name, subnet.name)]
 output subnets array = virtualNetwork.properties.subnets
 output vnetName string = virtualNetwork.name
 output vnetResourceId string = virtualNetwork.id

--- a/bicep/modules/virtual-network.bicep
+++ b/bicep/modules/virtual-network.bicep
@@ -5,39 +5,35 @@ param environment string
 param location string
 param tags object
 param vnetParams object
+param routeTableId string
 
-module routeTable 'br/SharedDefraRegistry:network.route-table:0.4.2' = {
-  name: 'route-table-aks-${deploymentId}'
-  params: {
-    name: '${vnetParams.routeTable.name}'
-    location: location
-    lock: ''
-    tags: tags
-    disableBgpRoutePropagation: true
-    routes: [
-      {
-        name: 'Default'
-        properties: {
-          addressPrefix: '0.0.0.0/0'
-          nextHopType: 'VirtualAppliance'
-          nextHopIpAddress: vnetParams.routeTable.virtualApplianceIp
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
+  name: vnetParams.name
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: vnetParams.addressPrefixes
+    }
+    dhcpOptions: {
+      dnsServers: vnetParams.dnsServers
+    }
+    subnets: [for subnet in vnetParams.subnets: {
+      name: subnet.name
+      properties: {
+        addressPrefix: subnet.addressPrefix
+        delegations: subnet.?delegations ?? []
+        serviceEndpoints: subnet.?serviceEndpoints ?? []
+        privateEndpointNetworkPolicies: subnet.?privateEndpointNetworkPolicies ?? 'Enabled'
+        privateLinkServiceNetworkPolicies: subnet.?privateLinkServiceNetworkPolicies ?? 'Enabled'
+        routeTable: {
+          id: subnet.?routeTableId ?? routeTableId
+        }
+        networkSecurityGroup: {
+          id: subnet.networkSecurityGroupId
         }
       }
-    ]
-  }
-}
-
-module virtualNetwork 'br/SharedDefraRegistry:network.virtual-network:0.4.2' = {
-  name: 'virtual-network-${deploymentId}'
-  params: {
-    name: vnetParams.name
-    location: location
-    lock: ''
-    tags: tags
-    enableDefaultTelemetry: true
-    addressPrefixes: vnetParams.addressPrefixes
-    dnsServers: vnetParams.dnsServers
-    subnets: vnetParams.subnets
+    }]
   }
 }
 
@@ -55,13 +51,8 @@ module vnetNetworkContributor './vnet-role-assignment.bicep' = [for principalId 
   dependsOn: [virtualNetwork]
 }]
 
-resource vnet 'Microsoft.Network/virtualNetworks@2025-05-01' existing = {
-  name: vnetParams.name
-  dependsOn: [virtualNetwork]
-}
-
-output subnetIds array = virtualNetwork.outputs.subnetResourceIds
-output subnets array = vnet.properties.subnets
-output vnetName string = virtualNetwork.outputs.name
-output vnetResourceId string = virtualNetwork.outputs.resourceId
+output subnetIds array = [for subnet in virtualNetwork.properties.subnets: subnet.id]
+output subnets array = virtualNetwork.properties.subnets
+output vnetName string = virtualNetwork.name
+output vnetResourceId string = virtualNetwork.id
 


### PR DESCRIPTION
## IMTA-20995: Swap out the CCoE route-table/vnet modules for our own resources

### What's this about

Basically, `network.route-table` and `network.virtual-network` (the CCoE modules we've been using) don't know about `privateLinkServiceNetworkPolicies`. So every time we've stood up a Private Link Service, someone's had to go into the Portal afterward and flip that setting by hand. It works, but it's not in code, nobody remembers to do it consistently, and it can drift without anyone noticing. 

### What I changed

- Added `bicep/modules/route-table.bicep` — pulled the route table out into its own module, same pattern we already use for NSGs. It sits alongside `nsg` in `20-network.bicep` now rather than being buried inside the vnet module.

- Rewrote `bicep/modules/virtual-network.bicep` to declare the vnet directly instead of calling the CCoE module. Subnets are built explicitly now, which means `privateLinkServiceNetworkPolicies` (the whole point of this) is finally set from Bicep instead of the Portal.

- Small addition to `20-network.bicep` to wire the new route table module into the vnet module.

- While I was in there, I also caught and fixed two defaults that didn't match what's actually live in DEV (found this by running `what-if` and comparing against the real deployed vnet):
  - `privateEndpointNetworkPolicies` now defaults to `Disabled`, not `Enabled` — turns out that's what's actually live on most of our subnets already - must have been done manually before?
  - `privateEndpointVNetPolicies: 'Disabled'` is now set explicitly at the vnet level — it was live but not represented in code anywhere, so it would've silently reset the first time we deployed.
- Didn't touch any of the outputs (`subnets`, `subnetIds`, `vnetName`, `vnetResourceId`) — kept them exactly as they were so nothing downstream needed changes.

### Against the original ticket

- Setting is now in the pipeline instead of a manual Portal step — done.
- `network.virtual-network` replaced with a native resource we own — done.
- `network.route-table` rolled off too — done.
- Bicepparam boilerplate reduction — partially done. Subnets can now omit `routeTableId` and fall back to the module's route table, but I left the existing bicepparam files untouched (still explicit per subnet) to keep this PR scoped to the module swap. Happy to do that cleanup as a fast follow if wanted.

### Testing

Ran `az deployment group what-if` against DEV a bunch of times (never actually deployed, just checked) while I iterated. Landed on:
- Both the vnet and route table come back as a plain in-place `Modify` — good, means swapping the module doesn't blow away and recreate the actual Azure resources.
- No more diff on any of the policy settings — matches what's live.

(Attached the manual what-if with baseline from main and from branch in the ticket - https://eaflood.atlassian.net/browse/IMTA-20995

### Heads up for whoever reviews this

You'll still see two things in a clean `what-if` run —  they're not from this PR, but worth to check:

1. **NSG rules getting flagged for removal** on all four NSGs (`CCoE-Deny-ZXA-Inbound`, `CCoE-SOC-Deny-IOC-Inbound`). These look like they're injected by some external security policy — not anything declared in our `nsgParams`.  I checked: this same diff shows up if you run `what-if` against `main` right now with zero changes. Separate problem, someone should probably sync up with whoever owns that policy at some point ?

2. **The vnet peerings show up as being removed.** Scared me too at first, given one of them is the hub peering. I checked this by running the exact same `what-if` against unmodified `main` and it shows the identical line — so is it just how `what-if` reports on this vnet, not something this change causes? Real deploys are incremental and won't touch peerings (I believe so)

### One more thing

Didn't need to touch any of the bicepparam files — the subnet-level policy settings were already declared correctly in DEV/TST/PRE/PRD, the CCoE module was just ignoring them. Would still recommend a quick `what-if` per environment before merging, just to be safe.