### PR TITLE
Explicitly set `proxy_read_timeout` and `proxy_send_timeout` in nginx site config

### DIFF
--- a/helm-charts/bootstrap/values.yaml
+++ b/helm-charts/bootstrap/values.yaml
@@ -31,6 +31,8 @@ originIngress:
     nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
     nginx.ingress.kubernetes.io/proxy-busy-buffers-size: "64k"
     nginx.ingress.kubernetes.io/proxy-body-size: "102m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Original-Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/helm-charts/bootstrap/values.yaml
+++ b/helm-charts/bootstrap/values.yaml
@@ -31,8 +31,8 @@ originIngress:
     nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
     nginx.ingress.kubernetes.io/proxy-busy-buffers-size: "64k"
     nginx.ingress.kubernetes.io/proxy-body-size: "102m"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "59"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "59"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Original-Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
~In this instance, to accommodate longer processing times when downloading large zip archives~
Reduced both timeouts to 59s, in order to come in under the default AFD origin timeout of 60s